### PR TITLE
Add support for live ebuilds

### DIFF
--- a/gentoo-test-package
+++ b/gentoo-test-package
@@ -164,7 +164,7 @@ class Docker:
         # docker container.
         self.execute("echo FEATURES=\\\"-sandbox -usersandbox\\\" " +
                      ">> /etc/portage/make.conf")
-        self.execute(("echo MAKEOPTS=\\\"-j%d\\\" " % (options.threads)) +
+        self.execute("echo MAKEOPTS=\\\"-j{}\\\" ".format(options.threads) +
                      ">> /etc/portage/make.conf")
 
     def _enable_overlays(self, overlays):
@@ -186,13 +186,8 @@ class Docker:
         if options.atom is not None:
             for a in options.atom:
                 self.execute(
-                    "echo \"" + a + "\" ~amd64 >> " +
+                    "echo \"" + a + "\" ** >> " +
                     "/etc/portage/package.accept_keywords")
-            if len(options.use) > 0:
-                for a in options.atom:
-                    self.execute(
-                        "echo %s %s >> /etc/portage/package.use/testbuild" %
-                        (a, " ".join(options.use)))
 
     def _unmask(self):
         """Unmask other atoms."""
@@ -203,6 +198,23 @@ class Docker:
             self.execute(
                 "echo \"%s\" ~amd64 >> /etc/portage/package.accept_keywords" %
                 a)
+
+    def _set_ebuild_use_flag(self, ebuild, use):
+        """Set the USE flags for a particular ebuild.
+
+        ebuild is a string and use is a list of strings.
+        """
+
+        self.execute("echo %s %s >> /etc/portage/package.use/testbuild" %
+                     (ebuild, " ".join(use)))
+
+    def _set_use_flags(self):
+        """Set USE flags on ebuild."""
+
+        self._set_ebuild_use_flag("git", ["curl"])
+        if options.atoms is not None and len(options.use) > 0:
+            for a in options.atom:
+                self._set_ebuild_use_flag(a, options.use)
 
     def _update(self):
         """Update container."""


### PR DESCRIPTION
Live ebuilds need to be unmasked with a `**`. In addition (at least
for git based repositories), git needs to the `curl` USE flag
enabled.